### PR TITLE
adding different models for the BH mass 1) oldschool SeBa 2) delayed …

### DIFF
--- a/include/star/black_hole.h
+++ b/include/star/black_hole.h
@@ -29,8 +29,12 @@ class black_hole : public single_star {
       private:
 
 	real suddenly_lost_mass;
-
+	real fallback;
 	real black_hole_mass(const real);
+	real black_hole_mass_seba(const real);
+	real black_hole_mass_delayed(const real);
+	real black_hole_mass_rapid(const real);
+	real black_hole_mass_startrack(const real);
 
       public :
          black_hole(hyper_giant &);
@@ -67,7 +71,7 @@ class black_hole : public single_star {
 	real gyration_radius_sq();
 	real angular_momentum();
 	
-        real sudden_mass_loss();
+    real sudden_mass_loss();
 
 	real get_radius();
 	real get_effective_radius() {return get_radius();}

--- a/include/star/constants.h
+++ b/include/star/constants.h
@@ -129,6 +129,7 @@ enum boolean_parameter {hyper_critical,
 			super_giant_disintegration,
 			proto_star_to_binary,
 			impulse_kick_for_black_holes,
+			fallback_kick_for_black_holes,
 			use_angular_momentum_tidal,
 			use_common_envelope_gamma_gamma,
 			use_common_envelope_alpha_alpha
@@ -221,6 +222,7 @@ class stellar_evolution_constants {  // Easy to have a name for compiling.
   real parameters(stellar_mass_limits);
   
   int use_common_envelope_method();
+  int use_black_hole_mass_method();  
 
   bool parameters(boolean_parameter);
   real parameters(accretion_parameter);

--- a/sstar/starclass/constants.C
+++ b/sstar/starclass/constants.C
@@ -120,6 +120,25 @@ PRC(pk);
     }
 }  
 
+// SilT&AD 28January 2022
+int stellar_evolution_constants::use_black_hole_mass_method() {
+    int bhm_parameter = 1; // SeBa model based on Fryer 2001
+    bhm_parameter = 2; // Fryer 2012 delayed model
+//    bhm_parameter = 3; // Fryer 2012 rapid model 
+//    bhm_parameter = 4; // Fryer 2012 Startrack model
+       
+  return bhm_parameter;
+}
+
+
+int stellar_evolution_constants::use_common_envelope_method() {
+  int cc_parameter = 1; // default (use alpha-gamma)
+  // cc_parameter = 2;     // default (use gamma-gamma)
+  //cc_parameter = 3;     // default (use alpha-alpha)
+  return cc_parameter;
+}
+
+
 real stellar_evolution_constants::parameters(astronomical_scale_parameter pa) {
 
     // Astronomical distance scale parameters in centimeters [cm]
@@ -268,12 +287,6 @@ real stellar_evolution_constants::parameters(stellar_mass_limits pm) {
     }
 }
 
-int stellar_evolution_constants::use_common_envelope_method() {
-  int cc_parameter = 1; // default (use alpha-gamma)
-  // cc_parameter = 2;     // default (use gamma-gamma)
-  //cc_parameter = 3;     // default (use alpha-alpha)
-  return cc_parameter;
-}
 
 bool stellar_evolution_constants::parameters(boolean_parameter pb) {
 
@@ -286,6 +299,8 @@ bool stellar_evolution_constants::parameters(boolean_parameter pb) {
         case proto_star_to_binary:                     return false;
              break;						    
         case impulse_kick_for_black_holes:             return true;
+             break;				
+        case fallback_kick_for_black_holes:             return true;
              break;				
         case use_angular_momentum_tidal:               return false;
 	     break;


### PR DESCRIPTION
…model Fryer 2012 3) rapid model Fryer 2012, 4) Startrack model from Fryer 2012. In constant.C use_black_hole_mass_method the user can specify which model to use. Default model is now model 2. Following Fryer 2012 the SN kick for BHs is also scaled down with the fallback mass. If this is not desired the user can set the the constant fallback_kick_for_black_holes to false.