### PR TITLE
Disable broken -DTOOLBOX so we can pass in CXXFLAGS from the environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CXXFLAGS  += -I./include -I./include/star -DHAVE_CONFIG_H -DTOOLBOX
+CXXFLAGS  += -I./include -I./include/star -DHAVE_CONFIG_H
 LDLIBS	  += -Lsstar -lsstar -Lnode -lnode -Lstd -lstd -lm
 CFLAGS    += -O
 CXXFLAGS  += -O

--- a/dstar/Makefile
+++ b/dstar/Makefile
@@ -1,6 +1,6 @@
 CXXFLAGS  += -I../include -I../include/star \
 	     -D_SRC_='"no_source_available"' \
-	     -DHAVE_CONFIG_H  -DTOOLBOX 
+	     -DHAVE_CONFIG_H
 LDLIBS	  += \
 	     -L. -ldstar \
 	     -L../sstar -lsstar \

--- a/rdc/Makefile
+++ b/rdc/Makefile
@@ -1,6 +1,6 @@
 CXXFLAGS  += -I../include -I../include/star \
 	     -D_SRC_='"no_source_available"' \
-	     -DHAVE_CONFIG_H  -DTOOLBOX 
+	     -DHAVE_CONFIG_H
 LDLIBS	  += \
 	     -L. -lrdc  \
 	     -L../dstar -ldstar  \


### PR DESCRIPTION
The main SeBa `Makefile` as well as several other `Makefiles` add `-DTOOLBOX` to `CXXFLAGS`. This flag seems to enable some extra code when applied.

Unfortunately that code is broken in various ways, causing compile errors. When compiling SeBa, this is hidden because the recursion in the Makefiles isn't implemented in the usual way, so that `CXXFLAGS` isn't passed on recursive calls, so that the flag gets dropped again on the way down, and is never actually applied.

If `CXXFLAGS` is set by the user, perhaps because they want to specify some more optimisation flags or because they're trying to make a package, the behaviour of `make` changes, and `CXXFLAGS` *is* passed down the line. As a result, the code is compiled with `-DTOOLBOX` in that case, and compilation fails.

```
make clean
# this works
make
```

```
make clean
# this breaks
CXXFLAGS="" make
```

It seems that this issue has been around for a long time, and that probably the code enabled by `-DTOOLBOX` isn't really used by anyone. I don't have time to fix it, but I would like to get rid of the weird work-around that AMUSE currently has to do to get SeBa to compile. So I'm submitting this PR that removes `-DTOOLBOX` from the Makefiles, so that I can compile normally and also pass the extra `CXXFLAGS` that I need when packaging.