### PR TITLE
Add a basic .gitignore to keep generated files out of the repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+Makefile.inc
+dstar/Makefile.inc
+**/*.o
+**/*.a
+starev
+


### PR DESCRIPTION
The title says it all really. This keeps generated files from showing up in `git status`, and makes `git add` ignore them, reducing the risk of accidentally checking in binaries and making it easier to make nice clean commits.