### PR TITLE
Use stellar type in add_star to enforce consistency at restarts

### DIFF
--- a/sstar/init/add_star.C
+++ b/sstar/init/add_star.C
@@ -106,7 +106,7 @@ void  addstar(node * b, real t_current, stellar_type type, real z,int id,
 	// Create a (single) star part, using the information obtained from
 	// the star story read in by get_node(), or created from scratch.
 
-	stellar_type local_type = NAS;
+	stellar_type local_type = type;
 	starbase * old_starbase = b->get_starbase();
 	story * s = old_starbase->get_star_story();
 


### PR DESCRIPTION
This fix ensures that the saved stellar type (used in `new_advanced_particle` in the AMUSE interface) is not overwritten in `addstar`. To enable consistent restarts, this must be implemented along with the changes in the AMUSE interface files outlined in [pull request #1105](https://github.com/amusecode/amuse/pull/1105).